### PR TITLE
Provide user with visibility of entire placeholder string

### DIFF
--- a/options.css
+++ b/options.css
@@ -18,6 +18,10 @@ body {
     border-radius: 4px;
 }
 
+.rule input {
+    min-width: 20em;
+}
+
 .rule button {
     padding: 5px 10px;
     background-color: #f44336; /* Red color for delete */


### PR DESCRIPTION
Currently, the input field's placeholder string may get truncated, preventing the user from seeing the required syntax.

This will fix that issue.